### PR TITLE
Removed dist info from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,6 @@
       "role": "Developer"
     }
   ],
-  "dist": {
-    "url": "https://github.com/curiosity26/ODataQuery-PHP.git",
-    "type": "git"
-  },
   "support": {
     "issues": "https://github.com/curiosity26/ODataQuery-PHP/issues",
     "wiki": "https://github.com/curiosity26/ODataQuery-PHP/wiki",


### PR DESCRIPTION
I removed this info because it causes an error when it's deployed on Heroku and it's not necessary because Composer will handle it when combined with Packagist.

```
[LogicException]                                                                                                 
remote:          Downloader "Composer\Downloader\GitDownloader" is a source type downloader and can not be used to download dist  
```
