### PR TITLE
Add single quote to string parameters in filters

### DIFF
--- a/src/Filter/Operators/Logical/ODataLogicalOperator.php
+++ b/src/Filter/Operators/Logical/ODataLogicalOperator.php
@@ -34,6 +34,8 @@ class ODataLogicalOperator extends ODataQueryFilter implements ODataConditionalI
         $value = $this->value;
         if ($value instanceof ODataMathematicalOperatorInterface) {
             $value = "($value)";
+        } else if (is_string($value)) {
+            $value = "'{$value}'";
         }
         return "$property $op $value";
     }


### PR DESCRIPTION
This change will add single quotes to string parameters, so for example if you try to filter:

```
$filter = new ODataEqualsOperator('displayId', 1000);
// results in Loans?$filter=displayId eq 1001

$filter = new ODataEqualsOperator('displayId', '1000');
// results in Loans?$filter=displayId eq '1001'
```

Otherwise I would get an error as the parameter is a string in my source, but the resulting path is trying to filter as an integer.
